### PR TITLE
RTL Support

### DIFF
--- a/src/PageFlip.ts
+++ b/src/PageFlip.ts
@@ -253,6 +253,17 @@ export class PageFlip extends EventObject {
     }
 
     /**
+     * Call a page direction change event trigger. Update UI and rendering area
+     *
+     * @param {boolean} newRTL - New page direction
+     */
+    public updateRTL(newRTL: boolean): void {
+        this.ui.setRTLStyle(newRTL);
+        this.update();
+        this.trigger('changeRTL', this, newRTL);
+    }
+
+    /**
      * Get the total number of pages in a book
      *
      * @returns {number}

--- a/src/Render/Render.ts
+++ b/src/Render/Render.ts
@@ -71,6 +71,7 @@ export abstract class Render {
     protected direction: FlipDirection = null;
     /** Current book orientation */
     protected orientation: Orientation = null;
+    protected rtl: boolean = null;
     /** Сurrent state of the shadows */
     protected shadow: Shadow = null;
     /** Сurrent animation process */
@@ -191,10 +192,16 @@ export abstract class Render {
     public update(): void {
         this.boundsRect = null;
         const orientation = this.calculateBoundsRect();
+        const rtl = this.app.getSettings().rtl;
 
         if (this.orientation !== orientation) {
             this.orientation = orientation;
             this.app.updateOrientation(orientation);
+        }
+
+        if (this.rtl !== rtl) {
+            this.rtl = rtl;
+            this.app.updateRTL(rtl);
         }
     }
 
@@ -337,6 +344,13 @@ export abstract class Render {
         return this.orientation;
     }
 
+    /**
+     * Get current book direction
+     */
+    public getRTL(): boolean {
+        return this.rtl;
+    }
+    
     /**
      * Set page area while flipping
      *

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -57,6 +57,8 @@ export interface FlipSetting {
 
     /** if this value is true, flipping by clicking on the whole book will be locked. Only on corners */
     disableFlipByClick: boolean;
+
+    rtl: boolean;
 }
 
 export class Settings {
@@ -82,6 +84,7 @@ export class Settings {
         useMouseEvents: true,
         showPageCorners: true,
         disableFlipByClick: false,
+        rtl: false,
     };
 
     /**

--- a/src/Style/stPageFlip.css
+++ b/src/Style/stPageFlip.css
@@ -59,3 +59,11 @@
   left: 0;
   top: 0;
 }
+
+/* rtl */
+.stf__wrapper.--rtl {
+  transform: scaleX(-1);
+}
+.stf__wrapper.--rtl .stf__item > * {
+  transform: scaleX(-1);
+}

--- a/src/UI/UI.ts
+++ b/src/UI/UI.ts
@@ -126,6 +126,21 @@ export abstract class UI {
         this.update();
     }
 
+    /**
+     * Updates styles based on book direction
+     *
+     * @param {boolean} rtl - New book direction
+     */
+    public setRTLStyle(rtl: boolean): void {
+        this.wrapper.classList.remove('--rtl');
+
+        if (rtl) {
+            this.wrapper.classList.add('--rtl');
+        }
+
+        this.update();
+    }
+    
     protected removeHandlers(): void {
         window.removeEventListener('resize', this.onResize);
 
@@ -159,9 +174,8 @@ export abstract class UI {
      */
     private getMousePos(x: number, y: number): Point {
         const rect = this.distElement.getBoundingClientRect();
-
         return {
-            x: x - rect.left,
+            x: this.app.getSettings().rtl ? rect.width - (x - rect.left) : x - rect.left,
             y: y - rect.top,
         };
     }


### PR DESCRIPTION

**Summary:**
Added support for right-to-left (RTL) languages (e.g., Arabic and Persian) by introducing an rtl prop to the settings.

**Changes:**
- add a new boolean prop `rtl` to the settings.
- When rtl is set to true, mirrors book and pages using CSS.
- Adjusts mouse x position in events for RTL support.

**Notes:**
- The only issue is that an additional parent element needs to be included within each paper element to mirror it. The paper element already has some styling, and to avoid altering it, I've added styles to mirror page to the inner element.
- This change does not impact existing functionality for left-to-right languages.
- Compatible with existing styling and does not introduce breaking changes.

**Issues Resolved:** #27 #13
